### PR TITLE
feat: enlarge NEXUS logo and add subline

### DIFF
--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -89,8 +89,11 @@ export function DashboardLayout({ children }: { children: ReactNode }) {
       <div className="hidden w-64 flex-shrink-0 border-r bg-card md:block">
         <div className="flex h-full flex-col">
           {/* Logo */}
-          <div className="flex h-16 items-center border-b px-6">
-            <span className="text-xl font-bold">NEXUS</span>
+          <div className="flex h-20 items-center border-b px-6">
+            <div className="flex flex-col">
+              <span className="text-2xl font-bold">NEXUS</span>
+              <span className="text-xs text-muted-foreground">Funding Rate Arbitrage</span>
+            </div>
           </div>
 
           {/* Navigation */}
@@ -106,7 +109,10 @@ export function DashboardLayout({ children }: { children: ReactNode }) {
         {/* Header */}
         <header className="flex h-16 items-center justify-between border-b px-6">
           <div className="flex items-center gap-4 md:hidden">
-            <span className="text-xl font-bold">NEXUS</span>
+            <div className="flex flex-col">
+              <span className="text-2xl font-bold">NEXUS</span>
+              <span className="text-xs text-muted-foreground">Funding Rate Arbitrage</span>
+            </div>
           </div>
 
           <div className="flex items-center gap-4 ml-auto">


### PR DESCRIPTION
Closes #1

This PR implements the requested logo adjustments:

- Increased logo font size from text-xl to text-2xl
- Increased sidebar logo container height to h-20 for better spacing
- Added 'Funding Rate Arbitrage' subline below NEXUS logo
- Applied changes to both desktop sidebar and mobile header

Generated with [Claude Code](https://claude.ai/code)